### PR TITLE
Modified gulp and npm to make automated testing cleaner (and prettier)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var Server = require('karma').Server;
 
 /* Check the platform before selecting a browswer */ 
 var browser = os.platform() === 'linux' ? ('google-chrome' || 'firefox') : (
-  os.platform() === 'darwin' ? ('google chrome' || 'safarai') : (
+  os.platform() === 'darwin' ? ('google chrome' || 'safari') : (
   os.platform() === 'win32' ? 'chrome' : 'iexplore'));
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,30 @@
+var os = require('os');
 var gulp = require('gulp')
+var open = require('gulp-open');
 var Server = require('karma').Server;
 
-/* Run our tests once, then quit */
-gulp.task('test', function(done) {
+/* Check the platform before selecting a browswer */ 
+var browser = os.platform() === 'linux' ? 'google-chrome' :  'firefox'(
+  os.platform() === 'darwin' ? 'google chrome' : 'safari' (
+  os.platform() === 'win32' ? 'chrome' : 'iexplore'));
+
+
+/* Run every unit test once, then quit */
+gulp.task('unitTests', function(done) {
     new Server({
         configFile: __dirname + '/karma.conf.js',
         singleRun: true
     }, done).start();
 });
+
+/* Wait for unitTests to finish, then open the generated report */
+gulp.task('openCodeCoverage', ['unitTests'], function(){
+  gulp.src('./reports/*/index.html')
+  .pipe(open({app: browser}));
+});
+
+/* Can run `gulp test` to just run unit tests */
+gulp.task('test', ['unitTests']);
+
+/* Can run `gulp test-coverage` run unit tests and then show the code coverage */
+gulp.task('test-coverage', ['unitTests', 'openCodeCoverage']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,8 +4,8 @@ var open = require('gulp-open');
 var Server = require('karma').Server;
 
 /* Check the platform before selecting a browswer */ 
-var browser = os.platform() === 'linux' ? 'google-chrome' :  'firefox'(
-  os.platform() === 'darwin' ? 'google chrome' : 'safari' (
+var browser = os.platform() === 'linux' ? ('google-chrome' || 'firefox') : (
+  os.platform() === 'darwin' ? ('google chrome' || 'safarai') : (
   os.platform() === 'win32' ? 'chrome' : 'iexplore'));
 
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "gulp": "^3.9.1",
     "gulp-coverage": "^0.3.38",
     "gulp-karma": "0.0.5",
+    "gulp-open": "^2.0.0",
     "jasmine": "2.6.0",
-    "karma-coverage": "^1.1.1",
     "nvm": "0.0.4"
   },
   "devDependencies": {
@@ -18,12 +18,13 @@
     "jasmine-core": "^2.6.4",
     "karma": "^1.7.0",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.4",
     "phantomjs": "^2.1.7"
   },
   "scripts": {
-    "test": "npm --version"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- `gulpfile.js`
    - Created a task to just run unit tests (run `gulp test`)
    - Created a task to run unit tests and then show a code coverage report (run `gulp test-coverage`)
- `package.json`
    - Added necessary packages
    - `npm test` will now run the unit tests to ensure they pass