### PR TITLE
Stretch: Drag and drop videos

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -3,7 +3,8 @@
 // Define the AdminUI module
 var app = angular.module('adminUI', [    
 	'ngRoute',
-	'angular-uuid'
+	'angular-uuid',
+    'ui.sortable'
 ]).config(function ($routeProvider) {
     $routeProvider
         .when("/", {

--- a/app/index.html
+++ b/app/index.html
@@ -33,13 +33,16 @@
 
   <!-- Style for toastr -->
   <link href="/bower_components/toastr/toastr.min.css" rel="stylesheet"/>
-	
+
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular.js"></script>
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/angular-ui/0.4.0/angular-ui.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
-  <script src="/bower_components/jquery/dist/jquery.min.js"></script>
   <script src="/bower_components/aws-sdk-js/dist/aws-sdk.min.js"></script>
   <script src="/bower_components/toastr/toastr.min.js"></script>
   <script src="/bower_components/angular-uuids/angular-uuid.js"></script>
+  <script src="/bower_components/angular-ui-sortable/sortable.min.js"></script>
   <script src="app.js"></script>
   <script src="controllers/PlaylistController.js"></script>
   <script src="controllers/ConfigController.js"></script>

--- a/app/services/schedulerService.js
+++ b/app/services/schedulerService.js
@@ -123,6 +123,7 @@ angular.module('adminUI')
                     // add it to the runnig queue (if running)
                     if(video.liveStatus !== status) {
                         video.liveStatus = status;
+                        video.locked = true;
                         // Push the video the list of UUIDs
                         if(status === "running") {
                             currentlyRunningVideos.push({uuid: video.uuid, order: video.order});

--- a/app/views/playlist.html
+++ b/app/views/playlist.html
@@ -14,11 +14,6 @@
                     <button type="button" class="btn btn-warning pull-right" ng-click="publish()">
                         <i class="glyphicon glyphicon-check"></i> Publish
                     </button>
-                    <a style="display: inline;">Reorder clip to:</a>
-                    <select id="newOrder" ng-model="newOrder" name="newOrder">
-                      <option value = "" disabled selected>Select...</option>
-                      <option ng-repeat="video in videos | filter: statusFilter"value="{{video.order}}">{{video.order}}</option>
-                    </select>
                 </div>
             </div>
             <div class="table-responsive">
@@ -35,9 +30,11 @@
                             <th></th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody ui-sortable="sortableOptions" ng-model="videos">
                         <!--<tr ng-repeat="v in videos | orderBy: 'order'" ng-style="{'background-color': '#e0827b'}">-->
-                        <tr ng-repeat="v in videos | orderBy: 'order'" ng-style="setRowColor(v.liveStatus)">
+                        <tr ng-repeat="v in videos | orderBy: 'order'" ng-class="{'not-sortable': v.locked}" class="v" ng-style="setRowColor(v.liveStatus)"
+                            dnd-draggable="v"
+                        >
                             <td>{{v.order}}</td>
                             <td><img ng-src={{v.thumbnail}}  alt="..." width="80" height="60" class="img-thumbnail" ></td>
                             <td>{{v.title}}</td>
@@ -47,7 +44,6 @@
                             <td>{{v.file}}</td>
                             <td>
                                 <div class="pull-right">
-									<button type="button"  ng-click="reorder(v.order)" class="btn btn-warning btn-sm"><span class="glyphicon glyphicon-sort"></span></button>
                                     <button type="button"  ng-click="remove(v.order)" class="btn btn-danger btn-sm"><span class="glyphicon glyphicon-trash"></span></button>
                                 </div>
                             </td>
@@ -123,7 +119,7 @@
                             <p class="help-block">Default option is the end of the playlist.</p>
                         </div>
                     </div>
-                    <div class="form-group" ng-show="playlistEmpty === true"> <!-- Only display the start time if the playlist is empty -->
+                    <div class="form-group" ng-show="{{playlistEmpty === true}}"> <!-- Only display the start time if the playlist is empty -->
                         <div class="col-sm-2">
                             <label for="videoStartTime">Start Time</label>
                         </div>

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "toastr": "~2.0.3",
     "aws-sdk-js": "~2.0.9",
     "angular-uuids": "0.0.4",
-    "jasmine-jquery": "^2.1.1"
+    "jasmine-jquery": "^2.1.1",
+    "angular-ui-sortable": "^0.17.2"
   },
   "ignore": [
     "**/.*",

--- a/js/test/PlaylistControllerTests.spec.js
+++ b/js/test/PlaylistControllerTests.spec.js
@@ -141,18 +141,18 @@ describe('PlaylistControllerTests', function(){
 			$scope.videoCount = $scope.videos.length;
 			$scope.newOrder = 2;
 			spyOn(schedulerService, 'playlistChanged');
-			
+
 			expect($scope.reorder(1)).toBe(0);
-			
+
 			expect(schedulerService.playlistChanged).toHaveBeenCalled();
 		});
 		it('should reorder from a lower order to a higher order properly', function(){
 			$scope.videos = [{num: 1, order: '1'}, {num: 2, order: '2'}, {num: 3, order: '3'}, {num: 4, order: '4'}, {num: 5, order: '5'} ];
 			$scope.videoCount = $scope.videos.length;
 			$scope.newOrder = 4;
-			
+
 			expect($scope.reorder(2)).toBe(0);
-			
+
 			expect($scope.videos[0].num).toBe(1);
 			expect($scope.videos[0].order).toBe('1');
 			expect($scope.videos[1].num).toBe(3);
@@ -160,7 +160,7 @@ describe('PlaylistControllerTests', function(){
 			expect($scope.videos[2].num).toBe(4);
 			expect($scope.videos[2].order).toBe('3');
 			expect($scope.videos[3].num).toBe(2);
-			expect($scope.videos[3].order).toBe('4');			
+			expect($scope.videos[3].order).toBe('4');
 			expect($scope.videos[4].num).toBe(5);
 			expect($scope.videos[4].order).toBe('5');
 		});
@@ -168,9 +168,9 @@ describe('PlaylistControllerTests', function(){
 			$scope.videos = [{num: 1, order: '1'}, {num: 2, order: '2'}, {num: 3, order: '3'}, {num: 4, order: '4'}, {num: 5, order: '5'} ];
 			$scope.videoCount = $scope.videos.length;
 			$scope.newOrder = 2;
-			
+
 			expect($scope.reorder(4)).toBe(0);
-			
+
 			expect($scope.videos[0].num).toBe(1);
 			expect($scope.videos[0].order).toBe('1');
 			expect($scope.videos[1].num).toBe(4);
@@ -178,12 +178,12 @@ describe('PlaylistControllerTests', function(){
 			expect($scope.videos[2].num).toBe(2);
 			expect($scope.videos[2].order).toBe('3');
 			expect($scope.videos[3].num).toBe(3);
-			expect($scope.videos[3].order).toBe('4');			
+			expect($scope.videos[3].order).toBe('4');
 			expect($scope.videos[4].num).toBe(5);
 			expect($scope.videos[4].order).toBe('5');
 		});
 	});
-	
+
 	describe('remove() tests', function() {
 		beforeEach((function(){
             PlaylistController = createPlaylistController($scope, $rootScope, S3Service, BXFGeneratorService, $q, $interval, uuid, schedulerService, currentVideoStatusService, mediaAssetsService, mediaProcessingService);
@@ -285,14 +285,14 @@ describe('PlaylistControllerTests', function(){
 		});
 
 		it('should set the color to green', function() {
-			var expectedResult = {'background-color': '#42f483'} 
+			var expectedResult = {'cursor': 'move', 'background-color': '#42f483'}
 			var result = $scope.setRowColor("done");
 			expect(result).toEqual(expectedResult);
 		});
 
-		it('should return nothing for anything else', function() {
+		it('should return a hovering cursor anything else', function() {
 			var result = $scope.setRowColor("foobar");
-			expect(result).toBe(undefined);
+			expect(result).toEqual({'cursor' : 'move'});
 		});
 	});
 	
@@ -785,6 +785,7 @@ describe('PlaylistControllerTests', function(){
 											   date: $scope.startTime,
 											   totalSeconds: 10,
 											   liveStatus: "ok",
+							                   locked: false,
 											   videoPlayed: false,
 											   uuid: "foo"
 											  }];
@@ -814,6 +815,7 @@ describe('PlaylistControllerTests', function(){
 											   date: $scope.startTime,
 											   totalSeconds: 10,
 											   liveStatus: "ok",
+											   locked: false,
 											   videoPlayed: false,
 											   uuid: "foo"
 											  }];
@@ -843,6 +845,7 @@ describe('PlaylistControllerTests', function(){
 											   date: $scope.startTime,
 											   totalSeconds: 10,
 											   liveStatus: "ok",
+											   locked: false,
 											   videoPlayed: false,
 											   uuid: "foo"
 											  }];
@@ -875,6 +878,7 @@ describe('PlaylistControllerTests', function(){
 											   date: $scope.startTime,
 											   totalSeconds: 10,
 											   liveStatus: "ok",
+							                   locked: false,
 											   videoPlayed: false,
 											   uuid: "foo"
 											  }];

--- a/js/test/PlaylistControllerTests.spec.js
+++ b/js/test/PlaylistControllerTests.spec.js
@@ -73,7 +73,20 @@ describe('PlaylistControllerTests', function(){
             expect($scope.startTime).toBe("");
             expect($scope.videoLength).toBe(0);
         });
-    });
+	});
+	
+	describe('sortableOptions', function() {
+		beforeEach(function() {
+            PlaylistController = createPlaylistController($scope, $rootScope, S3Service, BXFGeneratorService, $q, $interval, uuid, schedulerService, currentVideoStatusService, mediaAssetsService, mediaProcessingService);
+		});
+		it('should correctly set the order of the items', function() {
+			schedulerService.videos = [{order: 3}, {order: 5}, {order: 2}, {order: 1}, {order: 4}];
+			$scope.sortableOptions.stop();
+			var expectedResult = [{order: 1}, {order: 2}, {order: 3}, {order: 4}, {order: 5}];
+			expect(schedulerService.videos).toEqual(expectedResult);
+			expect($scope.videos).toEqual(expectedResult);
+		});
+	});
 	
     describe('resetForm() tests', function() {
         it('should correctly reset the form', function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,8 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
+            'https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js',
+            'https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js',
             'https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular.js',
             'https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular-route.js',
             'https://cdn.jsdelivr.net/npm/hls.js@latest',
@@ -25,11 +27,11 @@ module.exports = function (config) {
             'app/controllers/*.js', // can uncomment once all of the controllers are complete
             'app/directives/*.directive.js',
             'app/bower_components/aws-sdk-js/dist/aws-sdk.min.js',
-			'app/bower_components/angular-uuids/angular-uuid.js',
 			'app/bower_components/jquery/dist/jquery.min.js',
 			'app/bower_components/toastr/toastr.min.js',
             'app/bower_components/angular-uuids/angular-uuid.js',
             'app/bower_components/jasmine-jquery/lib/jasmine-jquery.js',
+            'app/bower_components/angular-ui-sortable/sortable.min.js',
 			'clientapp/app.js',
 			'clientapp/controllers/*',
         ],


### PR DESCRIPTION
Features
======
- A user can now drag and drop videos where they would like (had to use a jQuery library: [ui-sortable](https://github.com/angular-ui/ui-sortable))
- If a video is running or pending, the video cannot be dragged
- Reorder handle and drop down removed
- If a video is dragged where a locked position is, it won't be able to be dropped
- After a video dropped, the playlist automatically sorts the order

Issues
====
- None yet (but definitely test and let me know if anything comes up)